### PR TITLE
Fix $linkclass sometime not existing

### DIFF
--- a/mod_loginbutton.php
+++ b/mod_loginbutton.php
@@ -9,13 +9,10 @@
 
 defined('_JEXEC') or die;
 
-$logintext = htmlspecialchars($params->get('logintext', 'Log in'));
+$logintext  = htmlspecialchars($params->get('logintext', 'Log in'));
 $logouttext = htmlspecialchars($params->get('logouttext', 'Log out'));
-$linkclass = htmlspecialchars($params->get('linkclass'));
-
-if ($linkclass != '') :
-	$linkclass = ' class="' . $linkclass . '"';
-endif;
+$linkclass  = htmlspecialchars($params->get('linkclass', ''));
+$linkclass  = isset($linkclass) ? ' class="' . $linkclass . '"' : '';
 
 $user = JFactory::getUser();
 $userToken = JSession::getFormToken();


### PR DESCRIPTION
There was no default (fallback) value for `$linkclass`, so in the `default.php`, this would throw an error.

As fallback is now set and the PHP has been simplified a little